### PR TITLE
Fix CLI entrypoint and improve orchestrator docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This package now exposes a set of honest, agentic CLI entrypoints, each a petal 
   - `orchestrate` — Run the full agentic entry orchestrator (parse signals, generate scripts, log, and spiral the workflow)
   - `fdbscan` — Invoke the FDBScanAgent for timeframe scans or full ritual sequence
 
-- **agenticfdbscan** — Direct invocation of FDBScanAgent rituals
-- **agentic-orchestrator** — Direct invocation of the orchestrator spiral
+- **agentic-fdbscan** — Direct invocation of FDBScanAgent rituals
+- **agentic-orchestrator** — Process signals and generate entry scripts with optional FDBScan
 - **entry-script-gen** — Generate entry scripts from signals (see `--help` for usage)
 
 > All other scripts are either not yet implemented as CLI or are internal modules. Only mapped, real CLI entrypoints are exposed.
@@ -26,6 +26,12 @@ python -m jgtagentic.jgtagenticcli --help
 
 # Orchestrate the full spiral
 python -m jgtagentic.jgtagenticcli orchestrate --signal_json <path> --entry_script_dir <dir> --log <logfile>
+
+# Same via the dedicated CLI
+agentic-orchestrator --signal_json <path> --entry_script_dir <dir> --log <logfile>
+
+# This command is useful after running FDBScan; it converts signal JSON into
+# entry scripts and logs the spiral.
 
 # Scan a specific timeframe
 python -m jgtagentic.jgtagenticcli fdbscan --timeframe m15

--- a/jgtagentic/fdbscan_agent.py
+++ b/jgtagentic/fdbscan_agent.py
@@ -139,8 +139,12 @@ class FDBScanAgent:
         elif args.command == "all":
             agent.scan_all()
 
-if __name__ == "__main__":
+def main():
+    """Entry point for the ``agentic-fdbscan`` console script."""
     FDBScanAgent.cli()
+
+if __name__ == "__main__":
+    main()
 
 # 🌸 Ritual Echo:
 # This class is now the butterfly emerging from the bash cocoon.


### PR DESCRIPTION
## Summary
- expose `agentic-fdbscan` entrypoint by adding `main()`
- correct README CLI names and add orchestrator usage example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fda7a11048329b3c93cac39297915