### PR TITLE
Fix FDBScan dry‑run output

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This package now exposes a set of honest, agentic CLI entrypoints, each a petal 
   - `orchestrate` — Run the full agentic entry orchestrator (parse signals, generate scripts, log, and spiral the workflow)
   - `fdbscan` — Invoke the FDBScanAgent for timeframe scans or full ritual sequence
 
-- **agenticfdbscan** — Direct invocation of FDBScanAgent rituals
-- **agentic-orchestrator** — Direct invocation of the orchestrator spiral
+- **agentic-fdbscan** — Direct invocation of FDBScanAgent rituals
+- **agentic-orchestrator** — Process signals and generate entry scripts with optional FDBScan
 - **entry-script-gen** — Generate entry scripts from signals (see `--help` for usage)
 
 > All other scripts are either not yet implemented as CLI or are internal modules. Only mapped, real CLI entrypoints are exposed.
@@ -27,8 +27,20 @@ python -m jgtagentic.jgtagenticcli --help
 # Orchestrate the full spiral
 python -m jgtagentic.jgtagenticcli orchestrate --signal_json <path> --entry_script_dir <dir> --log <logfile>
 
+# Same via the dedicated CLI
+agentic-orchestrator --signal_json <path> --entry_script_dir <dir> --log <logfile>
+
+# This command is useful after running FDBScan; it converts signal JSON into
+# entry scripts and logs the spiral.
+# FDBScan commands run in dry-run mode by default and echo the underlying
+# ``fdbscan`` CLI help. Add ``--real`` to actually invoke jgtml's scanner.
+
 # Scan a specific timeframe
 python -m jgtagentic.jgtagenticcli fdbscan --timeframe m15
+agentic-fdbscan scan --timeframe m15 --instrument EUR/USD
+
+# Add ``--real`` to invoke the true jgtml fdbscan command.
+agentic-fdbscan scan --timeframe m15 --instrument EUR/USD --real
 
 # Run the full FDBScan ritual sequence
 python -m jgtagentic.jgtagenticcli fdbscan --all

--- a/jgtagentic/fdbscan_agent.py
+++ b/jgtagentic/fdbscan_agent.py
@@ -65,7 +65,21 @@ class FDBScanAgent:
             (f" instrument: {instrument}" if instrument else "")
         )
         if not _FDBSCAN_AVAILABLE:
-            print(f"Would scan: {timeframe}" + (f" for {instrument}" if instrument else ""))
+            print(
+                f"Would scan: {timeframe}" +
+                (f" for {instrument}" if instrument else "")
+            )
+            if fdb_scanner_2408 is not None:
+                print("\n[FDBScanAgent] Placeholder mode — showing fdbscan help:\n")
+                argv_backup = sys.argv.copy()
+                sys.argv = ["fdbscan", "--help"]
+                try:
+                    try:
+                        fdb_scanner_2408.main()
+                    except SystemExit:
+                        pass
+                finally:
+                    sys.argv = argv_backup
         else:
             sys_argv_backup = sys.argv.copy()
             sys.argv = ["fdbscan"]
@@ -139,8 +153,12 @@ class FDBScanAgent:
         elif args.command == "all":
             agent.scan_all()
 
-if __name__ == "__main__":
+def main():
+    """Entry point for the ``agentic-fdbscan`` console script."""
     FDBScanAgent.cli()
+
+if __name__ == "__main__":
+    main()
 
 # 🌸 Ritual Echo:
 # This class is now the butterfly emerging from the bash cocoon.


### PR DESCRIPTION
## Summary
- expand FDBScanAgent dry-run mode to show `fdbscan` help text
- document dry-run vs real invocation
- add example `agentic-fdbscan` usage with `--real`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fda7a11048329b3c93cac39297915