### PR TITLE
Improve FDBScan real mode handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,17 @@ agentic-orchestrator --signal_json <path> --entry_script_dir <dir> --log <logfil
 # entry scripts and logs the spiral.
 
 # FDBScan commands run in dry-run mode by default and echo the underlying
-# ``fdbscan`` CLI help. Add ``--real`` to actually invoke jgtml's scanner.
+# ``fdbscan`` CLI help. Add ``--real`` (or set ``FDBSCAN_AGENT_REAL=1``) to
+# actually invoke jgtml's scanner when available.
 
 
 # Scan a specific timeframe
 python -m jgtagentic.jgtagenticcli fdbscan --timeframe m15
 agentic-fdbscan scan --timeframe m15 --instrument EUR/USD
 
-# Add ``--real`` to invoke the true jgtml fdbscan command.
+# Add ``--real`` to invoke the true jgtml fdbscan command (requires
+# ``jgtml`` to be installed). You can also set ``FDBSCAN_AGENT_REAL=1`` to
+# default to real mode.
 agentic-fdbscan scan --timeframe m15 --instrument EUR/USD --real
 
 # Run the full FDBScan ritual sequence

--- a/tests/test_agentic_orchestrator.py
+++ b/tests/test_agentic_orchestrator.py
@@ -47,6 +47,29 @@ def test_fdbscan_agent_scan_timeframe(capsys):
     out = capsys.readouterr().out
     assert 'Would scan: m5' in out
 
+def test_fdbscan_agent_real_flag_without_scanner(monkeypatch, capsys):
+    monkeypatch.setattr('jgtagentic.fdbscan_agent._FDBSCAN_AVAILABLE', False)
+    agent = FDBScanAgent(real=True)
+    agent.scan_timeframe('m5')
+    out = capsys.readouterr().out
+    assert 'Real mode requested' in out
+    assert 'Would scan: m5' in out
+
+def test_fdbscan_agent_real_flag_with_scanner(monkeypatch, capsys):
+    calls = []
+
+    def dummy_main():
+        print('real scan executed')
+        calls.append(True)
+
+    monkeypatch.setattr('jgtagentic.fdbscan_agent._FDBSCAN_AVAILABLE', True)
+    monkeypatch.setattr('jgtagentic.fdbscan_agent.fdb_scanner_2408', type('D', (), {'main': staticmethod(dummy_main)}))
+    agent = FDBScanAgent(real=True)
+    agent.scan_timeframe('m5', 'EUR/USD')
+    out = capsys.readouterr().out
+    assert 'real scan executed' in out
+    assert calls
+
 def test_agentic_decider_decide(sample_signal):
     decider = AgenticDecider()
     result = decider.decide(sample_signal)


### PR DESCRIPTION
## Summary
- let FDBScanAgent `--real` work without extra environment variables
- warn when real mode requested but `jgtml` scanner is missing
- document `FDBSCAN_AGENT_REAL` env var
- add tests for real-mode behaviour

## Testing
- `pytest -q`
- `pytest tests/test_agentic_orchestrator.py::test_fdbscan_agent_real_flag_with_scanner -q`


------
https://chatgpt.com/codex/tasks/task_e_683fdf1feec48329ad82a23b1c5bf974