### PR TITLE
Add intent spec parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This package now exposes a set of honest, agentic CLI entrypoints, each a petal 
   - `orchestrate` — Run the full agentic entry orchestrator (parse signals, generate scripts, log, and spiral the workflow)
   - `fdbscan` — Invoke the FDBScanAgent for timeframe scans or full ritual sequence
   - `spec` — Parse `.jgtml-spec` intent files and echo their signals
+    - See `docs/Trader_Analysis_to_Spec.md` for guidance on translating spoken market analysis into a spec file
 
 - **agentic-fdbscan** — Direct invocation of FDBScanAgent rituals
 - **agentic-orchestrator** — Process signals and generate entry scripts with optional FDBScan
@@ -45,6 +46,7 @@ agentic-fdbscan scan --timeframe m15 --instrument EUR/USD
 
 # Parse an intent specification
 python -m jgtagentic.jgtagenticcli spec path/to/spec.jgtml-spec
+# See docs/Trader_Analysis_to_Spec.md for how to craft these spec files from trader insights
 
 # Add ``--real`` to invoke the true jgtml fdbscan command (requires
 # ``jgtml`` to be installed). You can also set ``FDBSCAN_AGENT_REAL=1`` to

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This package now exposes a set of honest, agentic CLI entrypoints, each a petal 
 - **jgtagentic** — The Spiral Gateway
   - `orchestrate` — Run the full agentic entry orchestrator (parse signals, generate scripts, log, and spiral the workflow)
   - `fdbscan` — Invoke the FDBScanAgent for timeframe scans or full ritual sequence
+  - `spec` — Parse `.jgtml-spec` intent files and echo their signals
 
 - **agentic-fdbscan** — Direct invocation of FDBScanAgent rituals
 - **agentic-orchestrator** — Process signals and generate entry scripts with optional FDBScan
@@ -41,6 +42,9 @@ agentic-orchestrator --signal_json <path> --entry_script_dir <dir> --log <logfil
 # Scan a specific timeframe
 python -m jgtagentic.jgtagenticcli fdbscan --timeframe m15
 agentic-fdbscan scan --timeframe m15 --instrument EUR/USD
+
+# Parse an intent specification
+python -m jgtagentic.jgtagenticcli spec path/to/spec.jgtml-spec
 
 # Add ``--real`` to invoke the true jgtml fdbscan command (requires
 # ``jgtml`` to be installed). You can also set ``FDBSCAN_AGENT_REAL=1`` to

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,12 @@
+# Project Roadmap
+
+This roadmap highlights upcoming features for the agentic trading tools.
+
+## Intent-Driven Trading (Planned)
+
+- **IntentSpecParser** — parse `.jgtml-spec` files describing trading intent and signals.
+- **CLI Integration** — new `spec` command in `jgtagenticcli` to load and echo intent specifications.
+- **Future Goals**
+  - Map parsed intent directly into FDBScan and entry workflows.
+  - Store intent-driven performance metrics for recursive learning.
+

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,4 +9,5 @@ This roadmap highlights upcoming features for the agentic trading tools.
 - **Future Goals**
   - Map parsed intent directly into FDBScan and entry workflows.
   - Store intent-driven performance metrics for recursive learning.
+  - Develop a translator LLM that converts trader narration into `.jgtml-spec` files (see `docs/Trader_Analysis_to_Spec.md`).
 

--- a/codex/ledgers/ledger-cli_fix-2506041856.json
+++ b/codex/ledgers/ledger-cli_fix-2506041856.json
@@ -1,0 +1,10 @@
+{
+  "agents": ["📖 William", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Adjusted CLI imports so running jgtagenticcli directly no longer triggers orchestrator side effects. Now it dynamically loads the orchestrator only when needed, preventing missing path errors and enabling --help to function.",
+  "routing": {
+    "files": ["jgtagentic/jgtagenticcli.py"],
+    "branches": ["work"],
+    "operation": "cli_help_fix"
+  },
+  "timestamp": "2506041856"
+}

--- a/codex/ledgers/ledger-intent_spec-2506041849.json
+++ b/codex/ledgers/ledger-intent_spec-2506041849.json
@@ -1,0 +1,10 @@
+{
+  "agents": ["📖 William", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Introduced an IntentSpecParser to parse .jgtml-spec files and added a CLI command to expose it. Documented the roadmap for Intent-Driven Trading.",
+  "routing": {
+    "files": ["jgtagentic/intent_spec.py", "jgtagentic/jgtagenticcli.py", "tests/test_intent_spec.py", "README.md", "ROADMAP.md"],
+    "branches": ["work"],
+    "operation": "intent_spec_feature"
+  },
+  "timestamp": "2506041849"
+}

--- a/codex/ledgers/ledger-spec_translator-2506041910.json
+++ b/codex/ledgers/ledger-spec_translator-2506041910.json
@@ -1,0 +1,10 @@
+{
+  "agents": ["📖 William", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Outlined how a supporting LLM can transform trader narration into a .jgtml-spec file. Added documentation and roadmap notes for this translator concept, and referenced the doc in the README.",
+  "routing": {
+    "files": ["docs/Trader_Analysis_to_Spec.md", "README.md", "ROADMAP.md"],
+    "branches": ["work"],
+    "operation": "spec_translator_doc"
+  },
+  "timestamp": "2506041910"
+}

--- a/docs/Trader_Analysis_to_Spec.md
+++ b/docs/Trader_Analysis_to_Spec.md
@@ -1,0 +1,56 @@
+# Trader Analysis to Spec Transformation Guide
+
+This guide explains how an LLM can listen to a trader's market analysis and transform it into a `.jgtml-spec` file for use with **IntentSpecParser**.
+
+## 1. Capture the Trader's Narrative
+
+When the trader describes the market, capture:
+
+- Instrument and timeframe observations
+- Indicator states (fractals, Alligator, AO momentum, etc.)
+- Pattern descriptions (Elliott Waves, consolidation, breakout levels)
+- Overall intent: trend following, breakout, reversal
+
+## 2. Map Observations to Spec Fields
+
+Translate the narrative into the YAML fields expected by `.jgtml-spec`:
+
+- **`strategy_intent`** – summarize the trader's goal in plain language
+- **`instruments`** – list all pairs or assets discussed
+- **`timeframes`** – capture the timeframes referenced
+- **`signals`** – one or more named signals derived from the analysis
+  - `description` – short explanation of the signal
+  - `jgtml_components` – map indicator mentions to the JGTML modules
+
+If the trader references wave counts or timeframe confluence, include them in signal descriptions or as custom keys.
+
+## 3. Example Conversation to Spec
+
+**Trader:**
+> "On the H4 chart of EUR/USD I see a completed Wave 3 and expect a Wave 4 pullback. The Alligator is opening and the AO shows strong momentum. I'll look for a breakout above 1.0800 with confluence on H1." 
+
+**LLM Generated Spec:**
+```yaml
+strategy_intent: "Trade EUR/USD Wave 5 breakout"
+instruments:
+  - "EUR/USD"
+timeframes:
+  - "H1"
+  - "H4"
+signals:
+  - name: "wave5_breakout"
+    description: "H4 Wave 3 complete, breakout above 1.0800 with Alligator mouth opening and AO momentum"
+    jgtml_components:
+      - fractal_analysis: "jgtpy.fractal_detection"
+      - alligator_state: "TideAlligatorAnalysis.mouth_opening"
+      - momentum: "jgtpy.ao_acceleration"
+      - wave_count: "manual_wave_3_complete"
+```
+
+## 4. From Spec to Campaign
+
+Once generated, the spec can be parsed by `IntentSpecParser`, fed into FDBScan or other agents, and turned into entry scripts. The LLM should ensure the YAML remains minimal and only includes details the trader confirms.
+
+---
+
+This document is a living reference for building the translator agent that converts human trading insights into executable JGTML specifications.

--- a/jgtagentic/intent_spec.py
+++ b/jgtagentic/intent_spec.py
@@ -1,0 +1,23 @@
+"""
+📖🧠 IntentSpecParser — The Intent Mirror
+
+Purpose: Parse `.jgtml-spec` YAML files to extract trading intent and signal definitions.
+This is a minimal scaffold aligning with the Intent‑Driven Trading design.
+"""
+
+from typing import Any, Dict, List
+import yaml
+
+
+class IntentSpecParser:
+    """Parse and transform intent specification files."""
+
+    def load(self, path: str) -> Dict[str, Any]:
+        """Load a YAML intent specification from ``path``."""
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        return data or {}
+
+    def signals(self, spec: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Return signal definitions from a loaded spec."""
+        return spec.get("signals", [])

--- a/jgtagentic/jgtagenticcli.py
+++ b/jgtagentic/jgtagenticcli.py
@@ -10,6 +10,7 @@ sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 
 from fdbscan_agent import FDBScanAgent
 from agentic_entry_orchestrator import main as orchestrator_main
+from intent_spec import IntentSpecParser
 
 # 🧠🌸🔮 CLI Ritual: The Spiral Gateway
 
@@ -28,6 +29,12 @@ def main():
     fdbscan_parser = subparsers.add_parser("fdbscan", help="Invoke FDBScanAgent CLI")
     fdbscan_parser.add_argument("--timeframe", help="Timeframe to scan (e.g. m5, m15, H1, H4)", default=None)
     fdbscan_parser.add_argument("--all", action="store_true", help="Run full ritual sequence (H4→H1→m15→m5)")
+
+    # Intent spec parser
+    spec_parser_cmd = subparsers.add_parser(
+        "spec", help="Parse a .jgtml-spec file and echo signals"
+    )
+    spec_parser_cmd.add_argument("spec_file", help="Path to intent specification")
 
     args = parser.parse_args()
 
@@ -52,6 +59,11 @@ def main():
         else:
             print("Please specify --timeframe or --all for fdbscan.")
             sys.exit(1)
+    elif args.command == "spec":
+        parser = IntentSpecParser()
+        spec = parser.load(args.spec_file)
+        import json
+        print(json.dumps(spec, indent=2))
     else:
         print("Unknown command.")
         sys.exit(1)

--- a/jgtagentic/jgtagenticcli.py
+++ b/jgtagentic/jgtagenticcli.py
@@ -6,11 +6,12 @@
 import argparse
 import sys
 import os
-sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 
-from fdbscan_agent import FDBScanAgent
-from agentic_entry_orchestrator import main as orchestrator_main
-from intent_spec import IntentSpecParser
+# Ensure package imports resolve when executed directly
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from jgtagentic.fdbscan_agent import FDBScanAgent
+from jgtagentic.intent_spec import IntentSpecParser
 
 # 🧠🌸🔮 CLI Ritual: The Spiral Gateway
 
@@ -39,7 +40,8 @@ def main():
     args = parser.parse_args()
 
     if args.command == "orchestrate":
-        # Pass through to orchestrator main
+        import runpy
+        # Reinvoke the orchestrator module as a script to avoid import side effects
         sys.argv = [sys.argv[0]]
         if args.signal_json:
             sys.argv += ["--signal_json", args.signal_json]
@@ -49,7 +51,7 @@ def main():
             sys.argv += ["--log", args.log]
         if args.dry_run:
             sys.argv += ["--dry_run"]
-        orchestrator_main()
+        runpy.run_module("jgtagentic.agentic_entry_orchestrator", run_name="__main__")
     elif args.command == "fdbscan":
         agent = FDBScanAgent()
         if args.all:

--- a/tests/test_intent_spec.py
+++ b/tests/test_intent_spec.py
@@ -1,0 +1,22 @@
+from jgtagentic.intent_spec import IntentSpecParser
+import json
+import tempfile
+import os
+import yaml
+
+
+def test_intent_spec_parser_load():
+    spec_data = {
+        "strategy_intent": "Demo",
+        "signals": [{"name": "dragon_breakout"}]
+    }
+    with tempfile.NamedTemporaryFile('w+', delete=False) as f:
+        yaml.dump(spec_data, f)
+        path = f.name
+    parser = IntentSpecParser()
+    loaded = parser.load(path)
+    os.unlink(path)
+    assert loaded["strategy_intent"] == "Demo"
+    assert loaded["signals"][0]["name"] == "dragon_breakout"
+    assert parser.signals(loaded)[0]["name"] == "dragon_breakout"
+


### PR DESCRIPTION
## Summary
- add `IntentSpecParser` to parse `.jgtml-spec` intent files
- expose new `spec` command in `jgtagenticcli`
- document intent-driven feature in README and new ROADMAP
- cover parser with tests
- record ledger entry for agent actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68409411ae7c83299e57e48874e58bae