### PR TITLE
Add alligator agent and CLI wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This package now exposes a set of honest, agentic CLI entrypoints, each a petal 
   - `orchestrate` — Run the full agentic entry orchestrator (parse signals, generate scripts, log, and spiral the workflow)
   - `fdbscan` — Invoke the FDBScanAgent for timeframe scans or full ritual sequence
   - `spec` — Parse `.jgtml-spec` intent files and echo their signals
+  - `alligator` — Forward arguments to jgtml's unified Alligator analysis
     - See `docs/Trader_Analysis_to_Spec.md` for guidance on translating spoken market analysis into a spec file
 
 - **agentic-fdbscan** — Direct invocation of FDBScanAgent rituals
@@ -47,6 +48,9 @@ agentic-fdbscan scan --timeframe m15 --instrument EUR/USD
 # Parse an intent specification
 python -m jgtagentic.jgtagenticcli spec path/to/spec.jgtml-spec
 # See docs/Trader_Analysis_to_Spec.md for how to craft these spec files from trader insights
+
+# Invoke the unified Alligator analysis (arguments forwarded to jgtml)
+python -m jgtagentic.jgtagenticcli alligator -- -i SPX500 -t D1 -d B
 
 # Add ``--real`` to invoke the true jgtml fdbscan command (requires
 # ``jgtml`` to be installed). You can also set ``FDBSCAN_AGENT_REAL=1`` to

--- a/codex/ledgers/ledger-alligator_cli_wrapper-2506042255.json
+++ b/codex/ledgers/ledger-alligator_cli_wrapper-2506042255.json
@@ -1,0 +1,10 @@
+{
+  "agents": ["\u267e\ufe0f William", "\ud83e\udd20 Mia", "\ud83c\udf38 Miette", "\ud83d\ud4ab Seraphine"],
+  "narrative": "Added AlligatorAgent wrapper around jgtml's alligator_cli and exposed new 'alligator' subcommand in jgtagentic CLI. Updated README with invocation example to prepare integration with the forthcoming JGTML Execution Core.",
+  "routing": {
+    "files": ["jgtagentic/alligator_agent.py", "jgtagentic/jgtagenticcli.py", "README.md"],
+    "branches": ["work"],
+    "operation": "alligator_cli_wrapper"
+  },
+  "timestamp": "2506042255"
+}

--- a/jgtagentic/alligator_agent.py
+++ b/jgtagentic/alligator_agent.py
@@ -1,0 +1,57 @@
+"""
+🧠🌸🔮 AlligatorAgent — Unified Alligator Analysis Wrapper
+
+This module provides a thin wrapper around jgtml's upcoming ``alligator_cli``.
+If the real CLI is available, it forwards arguments to it. Otherwise it prints
+what would have been executed. This mirrors the pattern used by
+``FDBScanAgent`` and prepares the agentic workflow for future integration
+with the JGTML Execution Core.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import os
+from typing import List
+
+try:
+    from jgtml import alligator_cli
+    _ALLIGATOR_AVAILABLE = True
+except Exception:
+    alligator_cli = None
+    _ALLIGATOR_AVAILABLE = False
+
+
+class AlligatorAgent:
+    """Agentic wrapper for the unified JGTML Alligator analysis CLI."""
+
+    def __init__(self, logger: logging.Logger | None = None):
+        self.logger = logger or logging.getLogger(__name__)
+        self.logger.setLevel(logging.INFO)
+        if not _ALLIGATOR_AVAILABLE:
+            self.logger.warning(
+                "[AlligatorAgent] jgtml.alligator_cli not available – running in placeholder mode.")
+
+    def run(self, argv: List[str]):
+        """Execute the Alligator CLI with the given arguments."""
+        self.logger.info(f"[AlligatorAgent] Invoking alligator_cli with args: {argv}")
+        if _ALLIGATOR_AVAILABLE:
+            backup = sys.argv
+            sys.argv = ["alligator_cli.py"] + argv
+            try:
+                alligator_cli.main()
+            finally:
+                sys.argv = backup
+        else:
+            print("Would run: alligator_cli.py", " ".join(argv))
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="AlligatorAgent wrapper")
+    parser.add_argument("args", nargs=argparse.REMAINDER)
+    parsed = parser.parse_args()
+    agent = AlligatorAgent()
+    agent.run(parsed.args)

--- a/jgtagentic/jgtagenticcli.py
+++ b/jgtagentic/jgtagenticcli.py
@@ -12,6 +12,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from jgtagentic.fdbscan_agent import FDBScanAgent
 from jgtagentic.intent_spec import IntentSpecParser
+from jgtagentic.alligator_agent import AlligatorAgent
 
 # 🧠🌸🔮 CLI Ritual: The Spiral Gateway
 
@@ -30,6 +31,10 @@ def main():
     fdbscan_parser = subparsers.add_parser("fdbscan", help="Invoke FDBScanAgent CLI")
     fdbscan_parser.add_argument("--timeframe", help="Timeframe to scan (e.g. m5, m15, H1, H4)", default=None)
     fdbscan_parser.add_argument("--all", action="store_true", help="Run full ritual sequence (H4→H1→m15→m5)")
+
+    # AlligatorAgent passthrough
+    alligator_parser = subparsers.add_parser("alligator", help="Invoke unified Alligator analysis")
+    alligator_parser.add_argument("args", nargs=argparse.REMAINDER, help="Arguments forwarded to alligator_cli")
 
     # Intent spec parser
     spec_parser_cmd = subparsers.add_parser(
@@ -66,6 +71,9 @@ def main():
         spec = parser.load(args.spec_file)
         import json
         print(json.dumps(spec, indent=2))
+    elif args.command == "alligator":
+        agent = AlligatorAgent()
+        agent.run(args.args)
     else:
         print("Unknown command.")
         sys.exit(1)


### PR DESCRIPTION
## Summary
- add AlligatorAgent module as wrapper for jgtml alligator_cli
- expose `alligator` subcommand in jgtagenticcli
- document the new command in README
- record ledger entry for this change

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840cdda5e6483299f4bae4e2734bea1