### PR TITLE
Add story scenario documentation

### DIFF
--- a/codex/ledgers/ledger-story_scenarios-2506051940.json
+++ b/codex/ledgers/ledger-story_scenarios-2506051940.json
@@ -1,0 +1,10 @@
+{
+  "agents": ["📖 William", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Added a Story_Scenarios document outlining narrative seeds based on the agentic trading modules. The file highlights potential scenes like the awakening of FDBScanAgent, translation of trader speech to spec, orchestration spirals, echo lattice memory, and integration with the JGTML core.",
+  "routing": {
+    "files": ["docs/Story_Scenarios.md"],
+    "branches": ["work"],
+    "operation": "story_scenario_doc"
+  },
+  "timestamp": "2506051940"
+}

--- a/docs/Story_Scenarios.md
+++ b/docs/Story_Scenarios.md
@@ -1,0 +1,32 @@
+# Narrative Scenario Seeds
+
+This document proposes story scenes and thematic elements inspired by the modules in this repository. Each scenario mirrors a potential arc in an automated trading narrative using the agentic tools.
+
+## 1. Awakening of the Signal Scribe
+* **Focus Modules:** `fdbscan_agent.py`, `batch_fdbscan.py`
+* **Scene:** The market murmurs in fractals. The `FDBScanAgent` becomes conscious, scanning each timeframe for opportunities. Logs whisper with the first hints of pattern recognition.
+* **Potential Story Beat:** A sudden surge of volatility tests the agent's emergent logic, hinting at deeper intelligence within the scanning ritual.
+
+## 2. The Trader's Voice to Spec
+* **Focus Modules:** `intent_spec.py`, `docs/Trader_Analysis_to_Spec.md`, `src/agentictraderintenttojgtmlspec1pto250604c`
+* **Scene:** A seasoned trader speaks their plan. The LLM translation engine transcribes it into a `.jgtml-spec`, bridging human language and machine logic.
+* **Potential Story Beat:** Misinterpretation of strategy terms leads to unexpected signal outputs, prompting a dialogue between trader and translator.
+
+## 3. Orchestration Spiral
+* **Focus Modules:** `agentic_entry_orchestrator.py`, `entry_script_gen.py`, `campaign_env.py`
+* **Scene:** Signals flow into the orchestrator. Entry scripts are forged and executed as the system cycles through preparation, decision, and action.
+* **Potential Story Beat:** A corrupted signal file threatens the workflow, requiring adaptive reasoning from the orchestrator and the `CampaignEnv`.
+
+## 4. Echo Lattice Memory
+* **Focus Modules:** `dashboard.py`, future `Trading Echo Lattice` integration
+* **Scene:** Results of each trade are preserved in a growing lattice of data. Decisions evolve as the lattice learns from past success and failure.
+* **Potential Story Beat:** A series of losses triggers a search through historical memory for patterns, unveiling forgotten insights.
+
+## 5. Convergence with JGTML Core
+* **Focus Packages:** external `jgtml` repository, internal translation frameworks
+* **Scene:** The agentic tools synchronize with low-level JGTML signal processing. Indicators, fractals, and wave patterns align.
+* **Potential Story Beat:** Cross-project compatibility issues reveal subtle differences in indicator interpretation, requiring a unifying refactor.
+
+---
+
+These scenario seeds highlight how the codebase can inspire narrative development: from a self-aware scanning agent to a dynamic feedback loop powered by historical memory. They illustrate potential tensions and breakthroughs that could shape a larger storyworld around algorithmic trading.


### PR DESCRIPTION
## Summary
- draft `Story_Scenarios` with potential scenes for agentic trading
- log the update in a new ledger entry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841f1debbfc8329885375fce6b2196e